### PR TITLE
Allow specifying modbus address though command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This script should work with any inverter that supports Modbus TCP and Sunspec s
 
 ## Requirements
 
+- [Net::Server](https://metacpan.org/pod/Net::Server) module
+- [Device::Modbus](https://metacpan.org/pod/Device::Modbus) module
 - [Device::Modbus::TCP](https://github.com/jfraire/Device-Modbus-TCP) module
 
 
@@ -66,6 +68,7 @@ syntax: sunspec-status [options] <host>
 
 Options:
  --port=<port>, -p <port>            Use port (default 502)
+ --address=<addr>, -a <addr>         Modbus Address (default 1)
  --meter=<meter>, -m <meter>         Query meter (default 1) 
                                       (meter = 1..3  or 0 = no meter)
  --phase=<phase>, -P <phase>         Report PF for single phase only

--- a/sunspec-status
+++ b/sunspec-status
@@ -29,6 +29,8 @@ use strict;
 
 my $TIMEOUT = 10;
 my $PORT = 502;
+my $ADDRESS = 1;
+my $address = $ADDRESS;
 
 my $SUNSPEC_I_COMMON_BLOCK_START = 40000;
 my $SUNSPEC_I_MODEL_BLOCK_START = 40069;
@@ -97,7 +99,7 @@ sub float32(*){
 sub get_inverter_common_block(*) {
     my ($ctx) = @_;
 
-    my $req = $ctx->read_holding_registers(unit=>1,
+    my $req = $ctx->read_holding_registers(unit=>$address,
 					   address=>$SUNSPEC_I_COMMON_BLOCK_START,
 					   quantity=>69);
     $ctx->send_request($req) || die("send_request(): failed");
@@ -136,7 +138,7 @@ sub get_inverter_common_block(*) {
 sub get_inverter_model_block(*) {
     my ($ctx) = @_;
 
-    my $req = $ctx->read_holding_registers(unit=>1,
+    my $req = $ctx->read_holding_registers(unit=>$address,
 					   address=>$SUNSPEC_I_MODEL_BLOCK_START,
 					   quantity=>52);
     $ctx->send_request($req) || die("send_request(): failed");
@@ -211,7 +213,7 @@ sub get_meter_common_block(**) {
     $meter=3 if ($meter > 3);
     my $offset = ($meter - 1) * 174;
 
-    my $req = $ctx->read_holding_registers(unit=>1,
+    my $req = $ctx->read_holding_registers(unit=>$address,
 					   address=>$SUNSPEC_M_COMMON_BLOCK_START + $offset,
 					   quantity=>65);
     $ctx->send_request($req) || die("send_request(): failed");
@@ -255,7 +257,7 @@ sub get_meter_model_block(**) {
     $meter=3 if ($meter > 3);
     my $offset = ($meter - 1) * 174;
 
-    my $req = $ctx->read_holding_registers(unit=>1,
+    my $req = $ctx->read_holding_registers(unit=>$address,
 					   address=>$SUNSPEC_M_MODEL_BLOCK_START + $offset,
 					   quantity=>107);
     $ctx->send_request($req) || die("send_request(): failed");
@@ -355,7 +357,7 @@ sub get_meter_model_block(**) {
 sub get_battery_common_block(*) {
     my ($ctx) = @_;
     
-    my $req = $ctx->read_holding_registers(unit=>1, address=>$SE_I_BATTERY_BLOCK_START, quantity=>65); #132
+    my $req = $ctx->read_holding_registers(unit=>$address, address=>$SE_I_BATTERY_BLOCK_START, quantity=>65); #132
     $ctx->send_request($req) || die("send_request(): failed");
     my $adu = $ctx->receive_response();
     die("Read of Battery Common block registers failed (device does not support SunSpec?)")
@@ -371,7 +373,7 @@ sub get_battery_common_block(*) {
     $b_cb->{Serial_Number}                  = unpack("A*",substr($data,48*2,16*2));
     $b_cb->{Device_ID}                      = unpack("n",substr($data,64*2,1*2 ));
 
-    $req = $ctx->read_holding_registers(unit=>1, address=>$SE_I_BATTERY_BLOCK_START+65+1, quantity=>10); #132
+    $req = $ctx->read_holding_registers(unit=>$address, address=>$SE_I_BATTERY_BLOCK_START+65+1, quantity=>10); #132
     $ctx->send_request($req) || die("send_request(): failed");
     $adu = $ctx->receive_response();
     die("Read of Battery Common block registers failed (device does not support SunSpec?)")
@@ -389,7 +391,7 @@ sub get_battery_common_block(*) {
     $b_cb->{Max_Discharge_Peak_Power}       = float32(substr($data,8*2,2*2 ));
 
 
-    $req = $ctx->read_holding_registers(unit=>1,
+    $req = $ctx->read_holding_registers(unit=>$address,
 					address=>$SE_I_BATTERY_BLOCK_START+76+32,
 					quantity=>30);
     $ctx->send_request($req) || die("send_request(): failed");
@@ -440,6 +442,7 @@ GetOptions("verbose|v" => \$verbose_mode,
 	   "battery|b" => \$battery,
 	   "debug|d" => \$debug_mode,
 	   "port|p=s" => \$port,
+	   "address|a=s" => \$address,
 	   "phase|P=s" => \$phase,
 	   "meter|m=s" => \$meter,
 	   "numeric|n" => \$numeric_mode,
@@ -453,6 +456,7 @@ unless ($host) {
   print STDERR "syntax: $0 [options] <host>\n\n",
     "Options:\n",
     " --port=<port>, -p <port>            Use port (default $PORT)\n",
+    " --address=<addr>, -a <addr>         Modbus Address (default $ADDRESS)\n",
     " --meter=<meter>, -m <meter>         Query meter (default 1) \n",
     "                                     (meter = 1..3  or 0 = no meter)\n",
     " --phase=<phase>, -P <phase>         Report single phase (default is average)\n",

--- a/tags
+++ b/tags
@@ -1,0 +1,24 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROC_CWD	/home/vinz/Projects/modbus/sunspec-monitor/	//
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	5.9.0	/p5.9.20210110.0/
+Examples	README.md	/^### Examples$/;"	S	section:sunspec-monitor""sunspec-status
+Requirements	README.md	/^## Requirements$/;"	s	chapter:sunspec-monitor
+Syntax	README.md	/^### Syntax$/;"	S	section:sunspec-monitor""sunspec-status
+dump_hash	sunspec-status	/^sub dump_hash(*) {$/;"	s
+float32	sunspec-status	/^sub float32(*){$/;"	s
+get_battery_common_block	sunspec-status	/^sub get_battery_common_block(*) {$/;"	s
+get_inverter_common_block	sunspec-status	/^sub get_inverter_common_block(*) {$/;"	s
+get_inverter_model_block	sunspec-status	/^sub get_inverter_model_block(*) {$/;"	s
+get_meter_common_block	sunspec-status	/^sub get_meter_common_block(**) {$/;"	s
+get_meter_model_block	sunspec-status	/^sub get_meter_model_block(**) {$/;"	s
+scale_value	sunspec-status	/^sub scale_value(**) {$/;"	s
+sunspec-monitor	README.md	/^# sunspec-monitor$/;"	c
+sunspec-status	README.md	/^## sunspec-status$/;"	s	chapter:sunspec-monitor


### PR DESCRIPTION
In case you want to merge this change I did:
-> Allow specifying modbus address though command-line arguments